### PR TITLE
OICI: 180 delete prescriber info before making it required

### DIFF
--- a/claim/migrations/0035_claim_care_type_claim_refer_from_claim_refer_to_and_more.py
+++ b/claim/migrations/0035_claim_care_type_claim_refer_from_claim_refer_to_and_more.py
@@ -11,6 +11,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL(
+            sql='UPDATE "tblClaim" SET "PrescriberID" = NULL;',
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql='DELETE FROM "tblPrescriber";',
+            reverse_sql=migrations.RunSQL.noop,
+        ),
         migrations.AlterField(
             model_name='prescriber',
             name='code',


### PR DESCRIPTION
Adds SQL operations to set all PrescriberID fields in tblClaim to NULL and deletes all records from tblPrescriber before altering the prescriber code field. This ensures data consistency for the upcoming schema change.